### PR TITLE
Can define a custom error callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If no callback is provided, res.render/res.renderMin sends the minified HTML to 
 express res.render does. Otherwise, the callback is called with the error object and the minified HTML content, as
 demonstrated above.
 
-Additionally, if no callback is provided - error handeling will be handled as explained when referencing displayErrors, but if you wish you can override this default behavor and define your own custom error callback such as this:
+Additionally, if no callback is provided - error handling will be handled as explained when referencing displayErrors, but if you wish you can override this default behavior and define your own custom error callback such as this:
 
 
 	app.use(minifyHTML({

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ demonstrated above.
 
 Additionally, if no callback is provided - error handling will be handled as explained when referencing displayErrors, but if you wish you can override this default behavior and define your own custom error callback such as this:
 
-
+```js
 	app.use(minifyHTML({
 		override:      true,
 		errCallback: function(err, req, res, next)
@@ -65,7 +65,8 @@ Additionally, if no callback is provided - error handling will be handled as exp
 			removeEmptyAttributes:     false,
 			minifyJS:                  true
 		}
-	}));	
+	}));
+```
 
 Full examples can naturally be found under the 'examples'-folder of this repository!
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ If no callback is provided, res.render/res.renderMin sends the minified HTML to 
 express res.render does. Otherwise, the callback is called with the error object and the minified HTML content, as
 demonstrated above.
 
+Additionally, if no callback is provided - error handeling will be handled as explained when referencing displayErrors, but if you wish you can override this default behavor and define your own custom error callback such as this:
+
+
+	app.use(minifyHTML({
+		override:      true,
+		errCallback: function(err, req, res, next)
+		{
+			next(err);
+		},
+		htmlMinifier: {
+			removeComments:            true,
+			collapseWhitespace:        true,
+			collapseBooleanAttributes: true,
+			removeAttributeQuotes:     true,
+			removeEmptyAttributes:     false,
+			minifyJS:                  true
+		}
+	}));	
+
 Full examples can naturally be found under the 'examples'-folder of this repository!
 
 ## License

--- a/minifier.js
+++ b/minifier.js
@@ -13,12 +13,11 @@ function minifyHTML(opts) {
             if (typeof callback === 'undefined') {
                 return function (err, html) {
                     if (err) {
-                        if (typeof opts.errCallback === 'function') //custom error callback specified
-                        {
+                        // Custom error callback specified
+                        if (typeof opts.errCallback === 'function') {
                             return opts.errCallback(err, req, res, next);
-                        }
-                        else //no custom error callback specified, default
-                        {
+                        } else {
+                            // no custom error callback specified, default
                             console.error(err)
                             if (opts.displayErrors === true) {
                                 res.send('Rendering error: ' + err.message);

--- a/minifier.js
+++ b/minifier.js
@@ -13,12 +13,20 @@ function minifyHTML(opts) {
             if (typeof callback === 'undefined') {
                 return function (err, html) {
                     if (err) {
-                        console.error(err)
-                        if (opts.displayErrors === true) {
-                            res.send('Rendering error: ' + err.message);
-                        } else {
-                            res.sendStatus(500);
+                        if (typeof opts.errCallback === 'function') //custom error callback specified
+                        {
+                            return opts.errCallback(err, req, res, next);
                         }
+                        else //no custom error callback specified, default
+                        {
+                            console.error(err)
+                            if (opts.displayErrors === true) {
+                                res.send('Rendering error: ' + err.message);
+                            } else {
+                                res.sendStatus(500);
+                            }
+                        }
+                        
                     } else {
                         html = minify(html, opts.htmlMinifier);
                         res.send(html);


### PR DESCRIPTION
Expresses default error handling callback is to just next( it. https://github.com/expressjs/express/blob/master/lib/response.js#L956

So I added a way to define a custom error callback to this module.

Basically the problem I had was: I allowed `override` as to keep the code original, but errors didn't get `next(` - they would be displayed or a 500 error never hitting my custom error handler depending on the `displayErrors` setting.

So `errCallback` is the new option. it lets you write your own custom code to handle errors when a callback for the res.render itself wasn't defined instead of using what this module defaults to.

Hopefully this one is simple enough.
