### PR TITLE
Added feature to skip minify in a urls list and minor code adjustments

### DIFF
--- a/minifier.js
+++ b/minifier.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var minify = require('html-minifier').minify;
+var objectMerge = require('object-merge'),
+    minify = require('html-minifier').minify;
 
 function minifyHTML(opts) {
 	var default_opts = {
@@ -11,18 +12,14 @@ function minifyHTML(opts) {
 			collapseWhitespace: true,
 			collapseBooleanAttributes: true,
 			removeAttributeQuotes: true,
-			removeEmptyAttributes: true,
-			minifyJS: true
+			removeEmptyAttributes: true
 		}
 	};
 
 	if (!opts || opts.constructor !== Object)
 		opts = {};
 
-	for (var attr in default_opts) {
-		if (!opts.hasOwnProperty(attr))
-			opts[attr] = default_opts[attr];
-	}
+    opts = objectMerge(default_opts, opts);
 
     if (opts.exception_url.constructor !== Array)
         opts.exception_url = [ opts.exception_url ];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/melonmanchan/express-minify-html#readme",
   "dependencies": {
-    "html-minifier": "2.1.6"
+    "html-minifier": "2.1.6",
+    "object-merge": "2.5.1"
   },
   "devDependencies": {
     "ejs": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-minify-html",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "description": "Express middleware around HTML minifier",
   "main": "minifier.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
     "html-minifier": "2.1.6"
   },
   "devDependencies": {
-    "ejs": "^2.4.1",
-    "express": "^4.13.4",
-    "express-handlebars": "^3.0.0",
-    "pug": "^0.1.0",
-    "supertest": "^1.2.0",
-    "tape": "^4.5.1",
-    "nunjucks": "2.4.1"
+    "ejs": "2.5.2",
+    "express": "4.14.0",
+    "express-handlebars": "3.0.0",
+    "fs": "0.0.1-security",
+    "handlebars": "4.0.6",
+    "nunjucks": "2.4.1",
+    "pug": "0.1.0",
+    "supertest": "1.2.0",
+    "tape": "4.6.2"
   }
 }

--- a/tests/test.output.raw.handlebars.html
+++ b/tests/test.output.raw.handlebars.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<!-- This unnecessary HTML comment should probably be removed! -->
+    <head class="head">
+        <meta charset="UTF-8">
+        <title>Express minify HTML test</title>
+    </head>
+    <body id="body">
+     Hello world
+    </body>
+    <script type="text/javascript">
+        function reallyNiceFunction   () {
+
+
+          return "Hello!";
+
+
+        };
+    </script>
+</html>

--- a/tests/test.output.raw.html
+++ b/tests/test.output.raw.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<!-- This unnecessary HTML comment should probably be removed! -->
+    <head class="head">
+        <meta charset="UTF-8">
+        <title>Express minify HTML test</title>
+    </head>
+    <body id="body">
+        Hello world
+    </body>
+    <script type="text/javascript">
+        function reallyNiceFunction   () {
+
+
+          return "Hello!";
+
+
+        };
+    </script>
+</html>

--- a/tests/test.output.raw.pug.html
+++ b/tests/test.output.raw.pug.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <!-- This unnecessary HTML comment should probably be removed!-->
+  <head class="head">
+    <meta charset="UTF-8">
+    <title>Express minify HTML test</title>
+  </head>
+  <body id="body">Hello world</body>
+  <script type="text/javascript">
+    function reallyNiceFunction   () {
+    return "Hello!";
+    };
+  </script>
+</html>


### PR DESCRIPTION
I loved this middleware, but unfortunately, I need to skip minify in some urls. 

I tried to create a middleware to call this middleware if the url isn't in the "skip list". Didn't work.

So I took the liberty, forked you code and made some adjustments to do what I needed in my application.

Usage:
```javascript
app.use(require('./vendor/express-minify-html')({
	override: true,
	exception_url: [
		'url_to_avoid_minify_html', // string support
		/regex_to_analyze_req_to_avoid_minify/i, // regex support
		function(req, res) { // function support
			// code to analyze req and decide if skips or not minify 
			// needs to return a boolean value
		}
	]
}));
```

I hope this small code change help other people too.

Does it make sense? Could you merge to your repo?

Yours Sincerely,
Julio Vedovatto - Brazil
